### PR TITLE
EDSC-2664: Preventing submission on enter

### DIFF
--- a/cypress/component/EDSCEchoForm.cy.js
+++ b/cypress/component/EDSCEchoForm.cy.js
@@ -5,7 +5,9 @@ import {
   prepopulatedXml,
   textfieldXml,
   treeWithSimplifyOutputXml,
-  notRelevantXml
+  notRelevantXml,
+  checkboxXml,
+  selectXml
 } from '../mocks/FormElement'
 import EDSCEchoform from '../../src'
 
@@ -177,6 +179,47 @@ describe('EDSCEchoform component', () => {
       hasChanged: true,
       model: '<prov:options xmlns:prov="http://www.example.com/orderoptions"><prov:textreference>New prepopulated value</prov:textreference></prov:options>',
       rawModel: '<prov:options xmlns:prov="http://www.example.com/orderoptions"><prov:textreference>New prepopulated value</prov:textreference></prov:options>'
+    })
+  })
+
+  it('calls preventDefault when Enter is pressed on any form element', () => {
+    cy.window().then((win) => {
+      cy.stub(win.Event.prototype, 'preventDefault').as('pd')
+    })
+
+    const formTypes = [
+      {
+        xml: textfieldXml,
+        selector: '#textinput'
+      },
+      {
+        xml: checkboxXml,
+        selector: '#boolinput'
+      },
+      {
+        xml: selectXml,
+        selector: '#selectinput'
+      },
+      {
+        xml: treeWithSimplifyOutputXml,
+        selector: '#ef-tree_filter_input'
+      }
+    ]
+
+    formTypes.forEach(({ xml, selector }) => {
+      setup(xml)
+
+      cy.get(selector).trigger('keydown', {
+        key: 'Enter',
+        code: 'Enter',
+        which: 13,
+        keyCode: 13,
+        bubbles: true,
+        cancelable: true
+      })
+
+      cy.get('@pd').should('have.been.called')
+      cy.get('@pd').invoke('resetHistory')
     })
   })
 })

--- a/cypress/component/EDSCEchoForm.cy.js
+++ b/cypress/component/EDSCEchoForm.cy.js
@@ -184,7 +184,7 @@ describe('EDSCEchoform component', () => {
 
   it('calls preventDefault when Enter is pressed on any form element', () => {
     cy.window().then((win) => {
-      cy.stub(win.Event.prototype, 'preventDefault').as('pd')
+      cy.stub(win.Event.prototype, 'preventDefault').as('preventDefaultStub')
     })
 
     const formTypes = [
@@ -218,8 +218,9 @@ describe('EDSCEchoform component', () => {
         cancelable: true
       })
 
-      cy.get('@pd').should('have.been.called')
-      cy.get('@pd').invoke('resetHistory')
+      cy.get('@preventDefaultStub').should('have.been.called')
+      // Reset the spy's history between iterations so each check is independent
+      cy.get('@preventDefaultStub').invoke('resetHistory')
     })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edsc/echoforms",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edsc/echoforms",
-      "version": "1.1.18",
+      "version": "1.1.19",
       "license": "Apache-2.0",
       "dependencies": {
         "diff-js-xml": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "Earthdata Search Components: ECHO Forms",
   "description": "A React component implementation of the ECHO Forms specification.",
   "main": "dist/index.js",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "scripts": {
     "build": "webpack",
     "start": "webpack serve --config example/webpack.config.js --mode development",

--- a/src/components/FormBody/FormBody.jsx
+++ b/src/components/FormBody/FormBody.jsx
@@ -15,7 +15,7 @@ export const FormBody = ({
 
   /**
    * Prevents form submission when Enter is pressed on any form element
-   * @param {Object} e event object
+   * @param {Object} keyPressEvent event object
    */
   const onKeyDown = (keyPressEvent) => {
     if (keyPressEvent.key === 'Enter') {

--- a/src/components/FormBody/FormBody.jsx
+++ b/src/components/FormBody/FormBody.jsx
@@ -17,9 +17,9 @@ export const FormBody = ({
    * Prevents form submission when Enter is pressed on any form element
    * @param {Object} e event object
    */
-  const onKeyDown = (e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault()
+  const onKeyDown = (keyPressEvent) => {
+    if (keyPressEvent.key === 'Enter') {
+      keyPressEvent.preventDefault()
     }
   }
 

--- a/src/components/FormBody/FormBody.jsx
+++ b/src/components/FormBody/FormBody.jsx
@@ -13,10 +13,24 @@ export const FormBody = ({
 
   let formBodyClassnames = 'form'
 
+  /**
+   * Prevents form submission when Enter is pressed on any form element
+   * @param {Object} e event object
+   */
+  const onKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+    }
+  }
+
   formBodyClassnames += ` ${className}`
 
   return (
-    <div className={elementClasses(formBodyClassnames, 'card')}>
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-static-element-interactions
+    <div
+      className={elementClasses(formBodyClassnames, 'card')}
+      onKeyDown={onKeyDown}
+    >
       <div className={elementClasses('form__body', 'card-body')}>
         {
           ui.childElementCount > 0 && Array.from(ui.children).map((element) => (

--- a/src/components/FormBody/FormBody.jsx
+++ b/src/components/FormBody/FormBody.jsx
@@ -26,7 +26,8 @@ export const FormBody = ({
   formBodyClassnames += ` ${className}`
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-static-element-interactions
+    // Disabling this rule because we want to capture events from bubbling up
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className={elementClasses(formBodyClassnames, 'card')}
       onKeyDown={onKeyDown}


### PR DESCRIPTION
# Overview

### What is the feature?

Preventing submit on enter in every form element.

### What is the Solution?

Adding prevent default on enter key press on every form element.

### What areas of the application does this impact?

EchoForms formbodies

# Testing

### Reproduction steps

1. Go to Earthdata Search 
2. Find a collection with form elements, like band subsetting
3. Focus on the form elements and click enter, no submission should occur

### Attachments

n/a

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the version field in package.json and ran npm install


